### PR TITLE
#6 Add Player, GameState, and Territory models with validation and unit tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,10 @@ repositories {
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.junit.platform:junit-platform-engine")
+    testImplementation("org.junit.platform:junit-platform-launcher")
+    // Source: https://mvnrepository.com/artifact/org.easymock/easymock
+    testImplementation("org.easymock:easymock:5.4.0")
 }
 
 java {

--- a/src/main/java/model/Continent.java
+++ b/src/main/java/model/Continent.java
@@ -1,0 +1,10 @@
+package model;
+
+public enum Continent {
+	ASIA,
+	AFRICA,
+	EUROPE,
+	NORTH_AMERICA,
+	SOUTH_AMERICA,
+	AUSTRALIA
+}

--- a/src/main/java/model/GamePhase.java
+++ b/src/main/java/model/GamePhase.java
@@ -1,0 +1,8 @@
+package model;
+
+public enum GamePhase {
+	SETUP,
+	REINFORCEMENT,
+	ATTACK,
+	FORTIFY
+}

--- a/src/main/java/model/GameState.java
+++ b/src/main/java/model/GameState.java
@@ -1,0 +1,59 @@
+package model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GameState {
+
+	private List<Player> players;
+	private List<Territory> territories;
+	private List<Player> turnOrder;
+	private Player currentPlayer;
+	private GamePhase currentPhase;
+
+	public GameState() {
+		this.players = new ArrayList<>();
+		this.territories = new ArrayList<>();
+		this.turnOrder = new ArrayList<>();
+	}
+
+	public List<Player> getPlayers() {
+		return players;
+	}
+
+	public void setPlayers(List<Player> players) {
+		this.players = players;
+	}
+
+	public List<Territory> getTerritories() {
+		return territories;
+	}
+
+	public void setTerritories(List<Territory> territories) {
+		this.territories = territories;
+	}
+
+	public List<Player> getTurnOrder() {
+		return turnOrder;
+	}
+
+	public void setTurnOrder(List<Player> turnOrder) {
+		this.turnOrder = turnOrder;
+	}
+
+	public Player getCurrentPlayer() {
+		return currentPlayer;
+	}
+
+	public void setCurrentPlayer(Player currentPlayer) {
+		this.currentPlayer = currentPlayer;
+	}
+
+	public GamePhase getCurrentPhase() {
+		return currentPhase;
+	}
+
+	public void setCurrentPhase(GamePhase currentPhase) {
+		this.currentPhase = currentPhase;
+	}
+}

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -1,0 +1,63 @@
+package model;
+
+public class Player {
+
+	private int id;
+	private String name;
+	private String color;
+	private int remainingArmiesToPlace;
+
+	public Player() {
+	}
+
+	public Player(int id, String name, String color, int remainingArmiesToPlace) {
+		setId(id);
+		setName(name);
+		setColor(color);
+		setRemainingArmiesToPlace(remainingArmiesToPlace);
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		if (id < 0) {
+			throw new IllegalArgumentException("id cannot be negative");
+		}
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("name cannot be null or blank");
+		}
+		this.name = name;
+	}
+
+	public String getColor() {
+		return color;
+	}
+
+	public void setColor(String color) {
+		if (color == null || color.trim().isEmpty()) {
+			throw new IllegalArgumentException("color cannot be null or blank");
+		}
+		this.color = color;
+	}
+
+	public int getRemainingArmiesToPlace() {
+		return remainingArmiesToPlace;
+	}
+
+	public void setRemainingArmiesToPlace(int remainingArmiesToPlace) {
+		if (remainingArmiesToPlace < 0) {
+			throw new IllegalArgumentException("remainingArmiesToPlace cannot be negative");
+		}
+		this.remainingArmiesToPlace = remainingArmiesToPlace;
+	}
+}

--- a/src/main/java/model/Territory.java
+++ b/src/main/java/model/Territory.java
@@ -1,0 +1,59 @@
+package model;
+
+public class Territory {
+	private String name;
+	private Player owner;
+	private int armyCount;
+	private Continent continent;
+
+	public Territory() {
+	}
+
+	public Territory(String name, Player owner, int armyCount, Continent continent) {
+		setName(name);
+		setOwner(owner);
+		setArmyCount(armyCount);
+		setContinent(continent);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("name cannot be null or blank");
+		}
+		this.name = name;
+	}
+
+	public Player getOwner() {
+		return owner;
+	}
+
+	public void setOwner(Player owner) {
+		this.owner = owner;
+	}
+
+	public int getArmyCount() {
+		return armyCount;
+	}
+
+	public void setArmyCount(int armyCount) {
+		if (armyCount < 0) {
+			throw new IllegalArgumentException("armyCount cannot be negative");
+		}
+		this.armyCount = armyCount;
+	}
+
+	public Continent getContinent() {
+		return continent;
+	}
+
+	public void setContinent(Continent continent) {
+		if (continent == null) {
+			throw new IllegalArgumentException("continent cannot be null");
+		}
+		this.continent = continent;
+	}
+}

--- a/src/test/java/model/GameStateTest.java
+++ b/src/test/java/model/GameStateTest.java
@@ -1,0 +1,59 @@
+package model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+public class GameStateTest {
+
+	@Test
+	void constructor_initializesCollectionsAsEmptyLists() {
+		GameState gameState = new GameState();
+
+		assertNotNull(gameState.getPlayers());
+		assertNotNull(gameState.getTerritories());
+		assertNotNull(gameState.getTurnOrder());
+		assertTrue(gameState.getPlayers().isEmpty());
+		assertTrue(gameState.getTerritories().isEmpty());
+		assertTrue(gameState.getTurnOrder().isEmpty());
+	}
+
+	@Test
+	void settersAndGetters_updateAllFields() {
+		GameState gameState = new GameState();
+
+		Player currentPlayer = EasyMock.createMock(Player.class);
+		List<Player> players = EasyMock.createMock(List.class);
+		List<Territory> territories = EasyMock.createMock(List.class);
+		List<Player> turnOrder = EasyMock.createMock(List.class);
+
+		EasyMock.expect(players.size()).andStubReturn(2);
+		EasyMock.expect(territories.size()).andStubReturn(1);
+		EasyMock.expect(turnOrder.size()).andStubReturn(2);
+
+		EasyMock.replay(currentPlayer, players, territories, turnOrder);
+
+		gameState.setPlayers(players);
+		gameState.setTerritories(territories);
+		gameState.setTurnOrder(turnOrder);
+		gameState.setCurrentPlayer(currentPlayer);
+		gameState.setCurrentPhase(GamePhase.ATTACK);
+
+		assertEquals(2, gameState.getPlayers().size());
+		assertEquals(1, gameState.getTerritories().size());
+		assertEquals(2, gameState.getTurnOrder().size());
+		assertSame(players, gameState.getPlayers());
+		assertSame(territories, gameState.getTerritories());
+		assertSame(turnOrder, gameState.getTurnOrder());
+		assertSame(currentPlayer, gameState.getCurrentPlayer());
+		assertEquals(GamePhase.ATTACK, gameState.getCurrentPhase());
+
+		EasyMock.verify(currentPlayer, players, territories, turnOrder);
+	}
+}

--- a/src/test/java/model/PlayerTest.java
+++ b/src/test/java/model/PlayerTest.java
@@ -1,0 +1,74 @@
+package model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class PlayerTest {
+
+	@Test
+	void allArgsConstructor_setsAllFields() {
+		Player player = new Player(1, "Alice", "Red", 5);
+
+		assertEquals(1, player.getId());
+		assertEquals("Alice", player.getName());
+		assertEquals("Red", player.getColor());
+		assertEquals(5, player.getRemainingArmiesToPlace());
+	}
+
+	@Test
+	void setters_updateValues() {
+		Player player = new Player();
+
+		player.setId(2);
+		player.setName("Bob");
+		player.setColor("Blue");
+		player.setRemainingArmiesToPlace(7);
+
+		assertEquals(2, player.getId());
+		assertEquals("Bob", player.getName());
+		assertEquals("Blue", player.getColor());
+		assertEquals(7, player.getRemainingArmiesToPlace());
+	}
+
+	@Test
+	void setId_withNegativeValue_throwsException() {
+		Player player = new Player();
+
+		assertThrows(IllegalArgumentException.class, () -> player.setId(-1));
+	}
+
+	@Test
+	void setName_withNullOrBlank_throwsException() {
+		Player player = new Player();
+
+		assertThrows(IllegalArgumentException.class, () -> player.setName(null));
+		assertThrows(IllegalArgumentException.class, () -> player.setName(""));
+		assertThrows(IllegalArgumentException.class, () -> player.setName("   "));
+	}
+
+	@Test
+	void setColor_withNullOrBlank_throwsException() {
+		Player player = new Player();
+
+		assertThrows(IllegalArgumentException.class, () -> player.setColor(null));
+		assertThrows(IllegalArgumentException.class, () -> player.setColor(""));
+		assertThrows(IllegalArgumentException.class, () -> player.setColor("   "));
+	}
+
+	@Test
+	void setRemainingArmiesToPlace_withNegativeValue_throwsException() {
+		Player player = new Player();
+
+		assertThrows(IllegalArgumentException.class, () -> player.setRemainingArmiesToPlace(-1));
+	}
+
+	@Test
+	void constructor_withInvalidArguments_throwsException() {
+		assertThrows(IllegalArgumentException.class, () -> new Player(-1, "Alice", "Red", 5));
+		assertThrows(IllegalArgumentException.class, () -> new Player(1, "", "Red", 5));
+		assertThrows(IllegalArgumentException.class, () -> new Player(1, "Alice", "", 5));
+		assertThrows(IllegalArgumentException.class, () -> new Player(1, "Alice", "Red", -1));
+	}
+}

--- a/src/test/java/model/TerritoryTest.java
+++ b/src/test/java/model/TerritoryTest.java
@@ -1,0 +1,79 @@
+package model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TerritoryTest {
+
+	@Test
+	void allArgsConstructor_setsAllFields() {
+		Player owner = new Player(1, "Alice", "Red", 5);
+		Territory territory = new Territory("Alaska", owner, 3, Continent.NORTH_AMERICA);
+
+		assertEquals("Alaska", territory.getName());
+		assertEquals(owner, territory.getOwner());
+		assertEquals(3, territory.getArmyCount());
+		assertEquals(Continent.NORTH_AMERICA, territory.getContinent());
+	}
+
+	@Test
+	void setters_updateValues() {
+		Territory territory = new Territory();
+		Player owner = new Player(2, "Bob", "Blue", 4);
+
+		territory.setName("Brazil");
+		territory.setOwner(owner);
+		territory.setArmyCount(6);
+		territory.setContinent(Continent.SOUTH_AMERICA);
+
+		assertEquals("Brazil", territory.getName());
+		assertEquals(owner, territory.getOwner());
+		assertEquals(6, territory.getArmyCount());
+		assertEquals(Continent.SOUTH_AMERICA, territory.getContinent());
+	}
+
+	@Test
+	void setOwner_allowsNull() {
+		Territory territory = new Territory();
+
+		territory.setOwner(null);
+
+		assertNull(territory.getOwner());
+	}
+
+	@Test
+	void setName_withNullOrBlank_throwsException() {
+		Territory territory = new Territory();
+
+		assertThrows(IllegalArgumentException.class, () -> territory.setName(null));
+		assertThrows(IllegalArgumentException.class, () -> territory.setName(""));
+		assertThrows(IllegalArgumentException.class, () -> territory.setName("   "));
+	}
+
+	@Test
+	void setArmyCount_withNegativeValue_throwsException() {
+		Territory territory = new Territory();
+
+		assertThrows(IllegalArgumentException.class, () -> territory.setArmyCount(-1));
+	}
+
+	@Test
+	void setContinent_withNull_throwsException() {
+		Territory territory = new Territory();
+
+		assertThrows(IllegalArgumentException.class, () -> territory.setContinent(null));
+	}
+
+	@Test
+	void constructor_withInvalidArguments_throwsException() {
+		Player owner = new Player(1, "Alice", "Red", 5);
+
+		assertThrows(IllegalArgumentException.class, () -> new Territory(null, owner, 3, Continent.NORTH_AMERICA));
+		assertThrows(IllegalArgumentException.class, () -> new Territory("", owner, 3, Continent.NORTH_AMERICA));
+		assertThrows(IllegalArgumentException.class, () -> new Territory("Alaska", owner, -1, Continent.NORTH_AMERICA));
+		assertThrows(IllegalArgumentException.class, () -> new Territory("Alaska", owner, 3, null));
+	}
+}


### PR DESCRIPTION
#6 
This pull request introduces core domain model classes and comprehensive unit tests for a Risk-style board game application. The main changes include the addition of model classes for `Player`, `Territory`, `GameState`, and related enums, each with proper validation and encapsulation. Thorough unit tests are provided for each model to ensure correct behavior and validation logic.

**Domain Model Implementation:**

* Added `Player` class with fields for id, name, color, and remaining armies, including validation in setters and constructors (`src/main/java/model/Player.java`).
* Added `Territory` class representing a territory with name, owner, army count, and continent, with validation for each property (`src/main/java/model/Territory.java`).
* Introduced `GameState` class to encapsulate the state of the game, including players, territories, turn order, current player, and phase, with appropriate getters, setters, and initialization (`src/main/java/model/GameState.java`).
* Added enums for `Continent` and `GamePhase` to represent valid continents and game phases (`src/main/java/model/Continent.java`, `src/main/java/model/GamePhase.java`). [[1]](diffhunk://#diff-39399142c527fa519b0c56590b498c91ebe9f991ec4591c7ca53382c73668ebbR1-R10) [[2]](diffhunk://#diff-d549193c3bbf55ce2b15a9fdfcb93d7a28b9c68ee25a07e85a4185b8198c142eR1-R8)

**Unit Testing:**

* Added comprehensive unit tests for `Player`, `Territory`, and `GameState` classes, covering constructor behavior, setters/getters, and validation logic (`src/test/java/model/PlayerTest.java`, `src/test/java/model/TerritoryTest.java`, `src/test/java/model/GameStateTest.java`). [[1]](diffhunk://#diff-e71da3cfda2c02ed81c10b511d420fe543787dd75e4f5805ad927935ff257d71R1-R74) [[2]](diffhunk://#diff-f7cc475384a6e14a42a109d9b376746ba09121f70efd0e1ddd5b11c176b0ee58R1-R79) [[3]](diffhunk://#diff-cde090d26fc24731c3aff0d06c0894a5dbb6b558685cad47d692e9f0c5029359R1-R59)