### PR TITLE
Starting new game/place one initial army on every assigned territory

### DIFF
--- a/docs/bva/TerritoryAssignmentService.md
+++ b/docs/bva/TerritoryAssignmentService.md
@@ -44,10 +44,10 @@
 
 ### Method under test: `placeInitialOneArmyPerTerritory(GameState gameState)`
 
-|              | State of the System | Expected output | Implemented?              |
-|--------------|---------------------|-----------------|---------------------------|
-| TC18_placeInitialOneArmy_emptyState | gameState has 0 territories assigned to any player | no territory army counts change | :x: |
-| TC19_placeInitialOneArmy_singleTerritory | gameState has 1 assigned territory with armyCount = 0 | that territory's armyCount becomes 1 | :x: |
-| TC20_placeInitialOneArmy_multipleTerritories | gameState has 2 assigned territories with armyCount values 0 and 0 | both territories' armyCount values become 1 | :x: |
-| TC21_placeInitialOneArmy_maxTerritories | gameState has 42 assigned territories, each with armyCount = 0 | all 42 territories end with armyCount = 1 | :x: |
+|              | State of the System                                                                              | Expected output | Implemented?             |
+|--------------|--------------------------------------------------------------------------------------------------|-----------------|--------------------------|
+| TC18_placeInitialOneArmy_emptyState | gameState has 0 territories assigned to any player                                               | no territory army counts change | :white_check_mark: |
+| TC19_placeInitialOneArmy_singleTerritory | gameState has 1 assigned territory with armyCount = 0                                            | that territory's armyCount becomes 1 | :white_check_mark: |
+| TC20_placeInitialOneArmy_multipleTerritories | gameState has 2 assigned territories with armyCount values 0 and 0                               | both territories' armyCount values become 1 | :white_check_mark: |
+| TC21_placeInitialOneArmy_maxTerritories | gameState has 42 (GameConstants.TOTAL_TERRITORIES) assigned territories, each with armyCount = 0 | all 42 territories end with armyCount = 1 | :white_check_mark: |
 

--- a/docs/bva/TerritoryAssignmentService.md
+++ b/docs/bva/TerritoryAssignmentService.md
@@ -42,3 +42,12 @@
 | TC16_assignTerritories_noPlayers  | state.players is empty | throws IllegalArgumentException | :white_check_mark: |
 | TC17_eachTerritory_hasOwner  | 2 players | each territory has non-null owner whose id matches player's id | :white_check_mark: |
 
+### Method under test: `placeInitialOneArmyPerTerritory(GameState gameState)`
+
+|              | State of the System | Expected output | Implemented?              |
+|--------------|---------------------|-----------------|---------------------------|
+| TC18_placeInitialOneArmy_emptyState | gameState has 0 territories assigned to any player | no territory army counts change | :x: |
+| TC19_placeInitialOneArmy_singleTerritory | gameState has 1 assigned territory with armyCount = 0 | that territory's armyCount becomes 1 | :x: |
+| TC20_placeInitialOneArmy_multipleTerritories | gameState has 2 assigned territories with armyCount values 0 and 0 | both territories' armyCount values become 1 | :x: |
+| TC21_placeInitialOneArmy_maxTerritories | gameState has 42 assigned territories, each with armyCount = 0 | all 42 territories end with armyCount = 1 | :x: |
+

--- a/src/main/java/service/TerritoryAssignmentService.java
+++ b/src/main/java/service/TerritoryAssignmentService.java
@@ -1,13 +1,10 @@
 package service;
 
+import java.util.List;
+
+import model.GameState;
 import model.Player;
 import model.Territory;
-import model.GameState;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
 
 public class TerritoryAssignmentService {
 
@@ -72,5 +69,9 @@ public class TerritoryAssignmentService {
 
 		// Update game state with territories
 		gameState.setTerritories(allTerritories);
+	}
+
+	public void placeInitialOneArmyPerTerritory(GameState state){
+		
 	}
 }

--- a/src/main/java/service/TerritoryAssignmentService.java
+++ b/src/main/java/service/TerritoryAssignmentService.java
@@ -72,6 +72,12 @@ public class TerritoryAssignmentService {
 	}
 
 	public void placeInitialOneArmyPerTerritory(GameState state){
-		
+
+		List<Territory> AllTeritories = state.getTerritories();
+
+		for (int i =0; i < AllTeritories.size(); i++) {
+			Territory territory = state.getTerritories().get(i);
+			territory.setArmyCount(1);
+		}
 	}
 }

--- a/src/test/java/service/TerritoryAssignmentServiceTest.java
+++ b/src/test/java/service/TerritoryAssignmentServiceTest.java
@@ -370,4 +370,25 @@ public class TerritoryAssignmentServiceTest {
         assertEquals(1, territory1.getArmyCount());
         assertEquals(1, territory2.getArmyCount());
     }
+
+    @Test
+    public void placeInitialOneArmy_maxTerritories() {
+        TerritoryAssignmentService service = new TerritoryAssignmentService();
+        GameState state = new GameState();
+        Player player = new Player(1, "Alice", "red", 5, new ArrayList<>());
+        List<Territory> territories = new ArrayList<>();
+
+        for (int i = 1; i <= GameConstants.TOTAL_TERRITORIES; i++) {
+            territories.add(new Territory("Territory " + i, player, 0, Continent.NORTH_AMERICA));
+        }
+
+        state.setTerritories(territories);
+
+        service.placeInitialOneArmyPerTerritory(state);
+
+        assertEquals(GameConstants.TOTAL_TERRITORIES, state.getTerritories().size());
+        for (Territory territory : state.getTerritories()) {
+            assertEquals(1, territory.getArmyCount());
+        }
+    }
 }

--- a/src/test/java/service/TerritoryAssignmentServiceTest.java
+++ b/src/test/java/service/TerritoryAssignmentServiceTest.java
@@ -1,12 +1,16 @@
 package service;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import domain.GameConstants;
@@ -321,5 +325,17 @@ public class TerritoryAssignmentServiceTest {
             assertTrue(t.getOwner().getId() == 1 || t.getOwner().getId() == 2,
                 "Territory " + t.getName() + " owner should be one of the players");
         }
+    }
+
+     @Test
+    public void placeInitialOneArmy_emptyState() {
+        TerritoryAssignmentService service = new TerritoryAssignmentService();
+        GameState state = new GameState();
+
+        state.setTerritories(List.of());
+
+        service.placeInitialOneArmyPerTerritory(state);
+
+        assertEquals(0, state.getTerritories().size());
     }
 }

--- a/src/test/java/service/TerritoryAssignmentServiceTest.java
+++ b/src/test/java/service/TerritoryAssignmentServiceTest.java
@@ -353,4 +353,21 @@ public class TerritoryAssignmentServiceTest {
         assertEquals(1, state.getTerritories().size());
         assertEquals(1, territory.getArmyCount());
     }
+
+    @Test
+    public void placeInitialOneArmy_multipleTerritories() {
+        TerritoryAssignmentService service = new TerritoryAssignmentService();
+        GameState state = new GameState();
+
+        Player player = new Player(1, "Alice", "red", 5, new ArrayList<>());
+        Territory territory1 = new Territory("Alaska", player, 0, Continent.NORTH_AMERICA);
+        Territory territory2 = new Territory("Northwest Territory", player, 0, Continent.NORTH_AMERICA);
+        state.setTerritories(List.of(territory1, territory2));
+
+        service.placeInitialOneArmyPerTerritory(state);
+
+        assertEquals(2, state.getTerritories().size());
+        assertEquals(1, territory1.getArmyCount());
+        assertEquals(1, territory2.getArmyCount());
+    }
 }

--- a/src/test/java/service/TerritoryAssignmentServiceTest.java
+++ b/src/test/java/service/TerritoryAssignmentServiceTest.java
@@ -327,7 +327,7 @@ public class TerritoryAssignmentServiceTest {
         }
     }
 
-     @Test
+    @Test
     public void placeInitialOneArmy_emptyState() {
         TerritoryAssignmentService service = new TerritoryAssignmentService();
         GameState state = new GameState();
@@ -337,5 +337,20 @@ public class TerritoryAssignmentServiceTest {
         service.placeInitialOneArmyPerTerritory(state);
 
         assertEquals(0, state.getTerritories().size());
+    }
+
+    @Test
+    public void placeInitialOneArmy_singleTerritory() {
+        TerritoryAssignmentService service = new TerritoryAssignmentService();
+        GameState state = new GameState();
+
+        Player player = new Player(1, "Alice", "red", 5, new ArrayList<>());
+        Territory territory = new Territory("Alaska", player, 0, Continent.NORTH_AMERICA);
+        state.setTerritories(List.of(territory));
+
+        service.placeInitialOneArmyPerTerritory(state);
+
+        assertEquals(1, state.getTerritories().size());
+        assertEquals(1, territory.getArmyCount());
     }
 }


### PR DESCRIPTION
implemented this. Already seems to be somewhat done in the "assign territories" method, but that can be reworked to just use this instead at the end for improved code clarity. 