### PR TITLE
Spotbugs fixes/new method/player.remove controlled territory

### DIFF
--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -22,6 +22,6 @@
 | TC11_setControlledTerritories_emptyListCreatesEmpty  | setControlledTerritories(emptyList) | player's list empty | :white_check_mark: |
 | TC12_getControlledTerritories_returnsCorrectList  | after additions | returned list contains expected territories | :white_check_mark: |
 | TC13_getControlledTerritoryCount_correctCount  | after additions | getControlledTerritoryCount returns accurate count | :white_check_mark: |
-| TC14_removeControlledTerritory_removesExistingTerritory  | removeControlledTerritory(existing Territory) | territory removed, count decreases | :x: |
+| TC14_removeControlledTerritory_removesExistingTerritory  | removeControlledTerritory(existing Territory) | territory removed, count decreases | :white_check_mark: |
 | TC15_removeControlledTerritory_missingTerritory  | removeControlledTerritory(Territory not controlled by player) | list unchanged, count unchanged | :x: |
 | TC16_removeControlledTerritory_fromEmptyList  | removeControlledTerritory(valid Territory) when player controls no territories | list remains empty, count remains 0 | :x: |

--- a/docs/bva/Player.md
+++ b/docs/bva/Player.md
@@ -22,3 +22,6 @@
 | TC11_setControlledTerritories_emptyListCreatesEmpty  | setControlledTerritories(emptyList) | player's list empty | :white_check_mark: |
 | TC12_getControlledTerritories_returnsCorrectList  | after additions | returned list contains expected territories | :white_check_mark: |
 | TC13_getControlledTerritoryCount_correctCount  | after additions | getControlledTerritoryCount returns accurate count | :white_check_mark: |
+| TC14_removeControlledTerritory_removesExistingTerritory  | removeControlledTerritory(existing Territory) | territory removed, count decreases | :x: |
+| TC15_removeControlledTerritory_missingTerritory  | removeControlledTerritory(Territory not controlled by player) | list unchanged, count unchanged | :x: |
+| TC16_removeControlledTerritory_fromEmptyList  | removeControlledTerritory(valid Territory) when player controls no territories | list remains empty, count remains 0 | :x: |

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -80,5 +80,9 @@ public class Player {
 		}
 	}
 
+	public void removeControlledTerritory(Territory territory) {
+		controlledTerritories.remove(territory);
+	}
+
 	
 }

--- a/src/test/java/model/PlayerTest.java
+++ b/src/test/java/model/PlayerTest.java
@@ -205,4 +205,18 @@ public class PlayerTest {
 		assertEquals(0, player.getControlledTerritoryCount());
 		assertFalse(player.getControlledTerritories().contains(territory));
 	}
+
+	@Test
+	void removeControlledTerritory_missingTerritory() {
+		Player player = new Player(1, "Alice", PlayerColor.RED, 10, new ArrayList<>());
+		Territory controlledTerritory = new Territory("Alaska", player, 1, Continent.NORTH_AMERICA);
+		Territory missingTerritory = new Territory("Brazil", player, 1, Continent.SOUTH_AMERICA);
+
+		player.addControlledTerritory(controlledTerritory);
+		player.removeControlledTerritory(missingTerritory);
+
+		assertEquals(1, player.getControlledTerritoryCount());
+		assertTrue(player.getControlledTerritories().contains(controlledTerritory));
+		assertFalse(player.getControlledTerritories().contains(missingTerritory));
+	}
 }

--- a/src/test/java/model/PlayerTest.java
+++ b/src/test/java/model/PlayerTest.java
@@ -193,4 +193,16 @@ public class PlayerTest {
 		player.addControlledTerritory(t2);
 		assertEquals(2, player.getControlledTerritoryCount());
 	}
+
+	@Test
+	void removeControlledTerritory_removesExistingTerritory() {
+		Player player = new Player(1, "Alice", PlayerColor.RED, 10, new ArrayList<>());
+		Territory territory = new Territory("Alaska", player, 1, Continent.NORTH_AMERICA);
+
+		player.addControlledTerritory(territory);
+		player.removeControlledTerritory(territory);
+
+		assertEquals(0, player.getControlledTerritoryCount());
+		assertFalse(player.getControlledTerritories().contains(territory));
+	}
 }

--- a/src/test/java/model/PlayerTest.java
+++ b/src/test/java/model/PlayerTest.java
@@ -219,4 +219,15 @@ public class PlayerTest {
 		assertTrue(player.getControlledTerritories().contains(controlledTerritory));
 		assertFalse(player.getControlledTerritories().contains(missingTerritory));
 	}
+
+	@Test
+	void removeControlledTerritory_fromEmptyList() {
+		Player player = new Player(1, "Alice", PlayerColor.RED, 10, new ArrayList<>());
+		Territory territory = new Territory("Alaska", player, 1, Continent.NORTH_AMERICA);
+
+		player.removeControlledTerritory(territory);
+
+		assertEquals(0, player.getControlledTerritoryCount());
+		assertTrue(player.getControlledTerritories().isEmpty());
+	}
 }


### PR DESCRIPTION
new method needed to prevent need for conquer Territory to modify referenced object. merging into spotbugs directly since it is related to that change